### PR TITLE
Update GZDoom to version 4.1.3

### DIFF
--- a/io.github.Freedoom-Phase-2.yaml
+++ b/io.github.Freedoom-Phase-2.yaml
@@ -58,10 +58,10 @@ modules:
   - -DCMAKE_CXX_FLAGS="-msse3" # Required when targeting 32-bit x86
   sources:
   - type: archive
-    url: https://github.com/coelckers/gzdoom/archive/g4.1.1.tar.gz
-    sha256: 50ce34b48518fb8715d6e346ff3ac8d08fd24b34e764be88335810fa592fb84a
+    url: https://github.com/coelckers/gzdoom/archive/g4.1.3.tar.gz
+    sha256: 5174c73e553d8ebbb5939255a6bdc56aecd4ff862ed20e544f271d59290a2d2b
   - type: file
-    url: https://github.com/coelckers/gzdoom/raw/g4.1.1/soundfont/gzdoom.sf2
+    url: https://github.com/coelckers/gzdoom/raw/g4.1.3/soundfont/gzdoom.sf2
     sha256: fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869
   - type: shell
     commands:
@@ -97,7 +97,7 @@ modules:
   - install -Dm 644 freedoom2.desktop -t /app/share/applications
   - install -Dm 644 freedoom2.appdata.xml -t /app/share/appdata
   - sed -e 's|</description>|<p>This package uses the GZDoom source port.</p></description>|' -i /app/share/appdata/freedoom2.appdata.xml
-  - sed -e 's|</component>|<releases><release version="4.1.1" date="2019-05-04"></release></releases></component>|' -i /app/share/appdata/freedoom2.appdata.xml
+  - sed -e 's|</component>|<releases><release version="0.11.3" date="2017-07-18"></release></releases></component>|' -i /app/share/appdata/freedoom2.appdata.xml
   - sed -e 's|</component>|<content_rating type="oars-1.1"><content_attribute id="violence-bloodshed">intense</content_attribute></content_rating></component>|' -i /app/share/appdata/freedoom2.appdata.xml
   - install -Dm 644 heada1-48x48.png /app/share/icons/hicolor/48x48/apps/freedoom2.png
   - install -Dm 644 heada1-64x64.png /app/share/icons/hicolor/64x64/apps/freedoom2.png


### PR DESCRIPTION
This also fixes the release information in the AppStream metadata to mention the latest Freedoom release instead of the latest GZDoom release.